### PR TITLE
Remove tenant from crud properties

### DIFF
--- a/Controller/CrudController.php
+++ b/Controller/CrudController.php
@@ -292,6 +292,8 @@ class CrudController extends Controller
         $publicMethods = get_class_methods($entity);
         $fields = [];
         foreach($publicMethods as $method) {
+            // we don't want to show the tenant property
+            if ($method == "getTenant") continue;
             if (false !== strpos($method, "get")) {
                 $method = str_replace("get", "", $method);
                 $fields[$this->from_camel_case($method)] = lcfirst($method);


### PR DESCRIPTION
We don't like to show the tenant as an user can only see his own tenant ( this should be implicit by subdomain).
